### PR TITLE
Add RPM Split Payment Demo page

### DIFF
--- a/rpmdemo/index.html
+++ b/rpmdemo/index.html
@@ -13,7 +13,7 @@
         />
         <meta
             property="og:image"
-            content="https://mredgyusv1qtkwdp.public.blob.vercel-storage.com/bdic/images/video-demo_social-image.png"
+            content="https://mredgyusv1qtkwdp.public.blob.vercel-storage.com/resolvr/rpmdemo/rpmdemo_social_card.png"
         />
         <meta property="og:type" content="website" />
 
@@ -21,7 +21,7 @@
         <meta name="twitter:card" content="summary_large_image" />
         <meta
             name="twitter:image"
-            content="https://mredgyusv1qtkwdp.public.blob.vercel-storage.com/bdic/images/video-demo_social-image.png"
+            content="https://mredgyusv1qtkwdp.public.blob.vercel-storage.com/resolvr/rpmdemo/rpmdemo_social_card.png"
         />
         <style>
             @import url("https://api.fontshare.com/v2/css?f[]=satoshi@400,500,700&display=swap");


### PR DESCRIPTION
## Summary
- Adds Resolvr-branded RPM Split Payment Demo landing page at `/rpmdemo`
- Landing view with autoplay logo lockup video and "Watch the Demo" button
- Demo view with full video player, play slate overlay, and "Learn more at resolvr.io" link

## Test plan
- [ ] Verify landing page loads with autoplay preview video
- [ ] Confirm "Watch the Demo" button reveals full demo video
- [ ] Check Resolvr branding (logo, colors, links) renders correctly