### PR TITLE
Fix Astrolabe mobile footer and form padding

### DIFF
--- a/astrolabe/index.html
+++ b/astrolabe/index.html
@@ -96,6 +96,19 @@
                 right: 0;
                 z-index: 100;
             }
+            @media (max-width: 768px) {
+                footer {
+                    padding: 0.75rem;
+                    font-size: 0.75rem;
+                }
+                main {
+                    margin-bottom: 48px;
+                }
+                .iframe-container {
+                    height: calc(100vh - 128px);
+                    padding-bottom: 60px;
+                }
+            }
         </style>
     </head>
     <body>


### PR DESCRIPTION
## Summary
- Reduce footer height on mobile for more scrollable area
- Add padding below the form iframe so the submit button isn't hidden by the fixed footer

## Test plan
- [ ] Verify footer is smaller on mobile (<768px)
- [ ] Confirm form submit button is visible and not obscured by footer