### PR TITLE
Add Aaron Daniel e-business card page

### DIFF
--- a/aaron/index.html
+++ b/aaron/index.html
@@ -1,0 +1,464 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Aaron Daniel — Resolvr</title>
+
+    <meta name="description" content="Aaron Daniel — Co-Founder & CEO at Resolvr" />
+    <meta property="og:title" content="Aaron Daniel — Resolvr" />
+    <meta property="og:description" content="Co-Founder & CEO at Resolvr" />
+    <meta property="og:image" content="https://storage.ghost.io/c/dd/91/dd911265-70bb-414f-8e9e-4279996996d3/content/images/2023/10/WBD-Profile-Pic-2--1-.jpg" />
+    <meta property="og:type" content="profile" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Aaron Daniel — Resolvr" />
+    <meta name="twitter:description" content="Co-Founder & CEO at Resolvr" />
+    <meta name="twitter:image" content="https://storage.ghost.io/c/dd/91/dd911265-70bb-414f-8e9e-4279996996d3/content/images/2023/10/WBD-Profile-Pic-2--1-.jpg" />
+
+    <link rel="icon" href="https://mredgyusv1qtkwdp.public.blob.vercel-storage.com/branding/logo/resolvr-logo-white.svg" type="image/svg+xml" />
+
+    <style>
+      @import url("https://api.fontshare.com/v2/css?f[]=satoshi@400,500,700&display=swap");
+
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      :root {
+        --orange: #fb923c;
+        --blue: #14affe;
+        --black: #000000;
+        --white: #ffffff;
+        --bg: var(--black);
+        --text: var(--white);
+        --text-muted: rgba(255, 255, 255, 0.6);
+        --card-bg: rgba(255, 255, 255, 0.06);
+        --card-border: rgba(255, 255, 255, 0.1);
+        --card-hover: rgba(255, 255, 255, 0.1);
+        color-scheme: dark;
+      }
+
+      [data-theme="light"] {
+        --bg: #f5f5f5;
+        --text: #111111;
+        --text-muted: rgba(0, 0, 0, 0.55);
+        --card-bg: rgba(0, 0, 0, 0.04);
+        --card-border: rgba(0, 0, 0, 0.1);
+        --card-hover: rgba(0, 0, 0, 0.08);
+        color-scheme: light;
+      }
+
+      body {
+        background: var(--bg);
+        color: var(--text);
+        font-family: "Satoshi", -apple-system, BlinkMacSystemFont, sans-serif;
+        min-height: 100dvh;
+        display: flex;
+        align-items: flex-start;
+        justify-content: center;
+        padding: 48px 20px 40px;
+        transition: background 0.3s, color 0.3s;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .card {
+        width: 100%;
+        max-width: 400px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 28px;
+      }
+
+      /* Theme toggle */
+      .theme-toggle {
+        position: fixed;
+        top: 16px;
+        right: 16px;
+        background: var(--card-bg);
+        border: 1px solid var(--card-border);
+        border-radius: 50%;
+        width: 40px;
+        height: 40px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        color: var(--text-muted);
+        transition: background 0.2s, color 0.2s;
+        z-index: 10;
+      }
+
+      .theme-toggle:hover {
+        background: var(--card-hover);
+        color: var(--text);
+      }
+
+      .theme-toggle svg {
+        width: 18px;
+        height: 18px;
+      }
+
+      .icon-sun { display: none; }
+      .icon-moon { display: block; }
+      [data-theme="light"] .icon-sun { display: block; }
+      [data-theme="light"] .icon-moon { display: none; }
+
+      /* Avatar */
+      .avatar {
+        width: 120px;
+        height: 120px;
+        border-radius: 50%;
+        object-fit: cover;
+        border: 3px solid var(--orange);
+      }
+
+      /* Identity */
+      .identity {
+        text-align: center;
+      }
+
+      .name {
+        font-size: 24px;
+        font-weight: 700;
+        line-height: 1.2;
+      }
+
+      .title {
+        font-size: 15px;
+        color: var(--text-muted);
+        margin-top: 4px;
+        font-weight: 400;
+      }
+
+      /* Resolvr block */
+      .resolvr-block {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 6px;
+        text-decoration: none;
+        transition: opacity 0.15s;
+      }
+
+      .resolvr-block:hover {
+        opacity: 0.8;
+      }
+
+      .resolvr-logo {
+        width: 160px;
+        height: auto;
+      }
+
+      .resolvr-url {
+        font-size: 13px;
+        color: var(--text-muted);
+        font-weight: 400;
+      }
+
+      /* Link sections */
+      .links {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .section-label {
+        font-size: 11px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-muted);
+        padding: 0 4px;
+        margin-top: 4px;
+      }
+
+      .link-item {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 14px 16px;
+        background: var(--card-bg);
+        border: 1px solid var(--card-border);
+        border-radius: 14px;
+        text-decoration: none;
+        color: var(--text);
+        transition: background 0.15s, transform 0.15s;
+      }
+
+      .link-item:hover {
+        background: var(--card-hover);
+        transform: translateY(-1px);
+      }
+
+      .link-item:active {
+        transform: translateY(0);
+      }
+
+      .link-icon {
+        width: 36px;
+        height: 36px;
+        border-radius: 10px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        background: var(--card-border);
+      }
+
+      .link-icon img {
+        width: 22px;
+        height: 22px;
+        object-fit: contain;
+      }
+
+      .link-icon svg {
+        width: 20px;
+        height: 20px;
+      }
+
+      .link-icon.branded {
+        background: transparent;
+      }
+
+      .link-icon.branded img,
+      .link-icon.branded svg {
+        width: 36px;
+        height: 36px;
+      }
+
+      .link-label {
+        font-size: 15px;
+        font-weight: 500;
+        line-height: 1.3;
+      }
+
+      .link-sublabel {
+        font-size: 12px;
+        color: var(--text-muted);
+        font-weight: 400;
+      }
+
+      .link-text {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .link-arrow {
+        margin-left: auto;
+        color: var(--text-muted);
+        flex-shrink: 0;
+      }
+
+      .link-arrow svg {
+        width: 16px;
+        height: 16px;
+      }
+
+      /* Social row */
+      .socials {
+        display: flex;
+        gap: 12px;
+        justify-content: center;
+        width: 100%;
+      }
+
+      .social-btn {
+        width: 48px;
+        height: 48px;
+        border-radius: 14px;
+        background: var(--card-bg);
+        border: 1px solid var(--card-border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-decoration: none;
+        color: var(--text);
+        transition: background 0.15s, transform 0.15s;
+      }
+
+      .social-btn:hover {
+        background: var(--card-hover);
+        transform: translateY(-1px);
+      }
+
+      .social-btn:active {
+        transform: translateY(0);
+      }
+
+      .social-btn svg {
+        width: 22px;
+        height: 22px;
+      }
+
+      /* Footer */
+      .footer {
+        font-size: 12px;
+        color: var(--text-muted);
+        text-align: center;
+        margin-top: 8px;
+      }
+
+      /* Light mode logo inversions */
+      [data-theme="light"] .logo-invert {
+        filter: invert(1);
+      }
+    </style>
+  </head>
+  <body>
+    <button class="theme-toggle" aria-label="Toggle theme">
+      <!-- Sun icon (shown in light mode) -->
+      <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <circle cx="12" cy="12" r="5"/><path d="M12 1v2m0 18v2M4.22 4.22l1.42 1.42m12.72 12.72l1.42 1.42M1 12h2m18 0h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>
+      </svg>
+      <!-- Moon icon (shown in dark mode) -->
+      <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
+      </svg>
+    </button>
+
+    <div class="card">
+      <img
+        class="avatar"
+        src="https://storage.ghost.io/c/dd/91/dd911265-70bb-414f-8e9e-4279996996d3/content/images/2023/10/WBD-Profile-Pic-2--1-.jpg"
+        alt="Aaron Daniel"
+      />
+
+      <div class="identity">
+        <div class="name">Aaron Daniel</div>
+        <div class="title">Co-Founder &amp; CEO</div>
+      </div>
+
+      <!-- Resolvr branding -->
+      <a class="resolvr-block" href="https://resolvr.io" target="_blank" rel="noopener">
+        <img class="resolvr-logo logo-invert" src="https://mredgyusv1qtkwdp.public.blob.vercel-storage.com/branding/logo/resolvr-logo-white.svg" alt="Resolvr" />
+        <span class="resolvr-url">resolvr.io</span>
+      </a>
+
+      <!-- Featured -->
+      <div class="links">
+        <div class="section-label">Featured</div>
+
+        <a class="link-item" href="https://bdic.io" target="_blank" rel="noopener">
+          <span class="link-icon branded">
+            <img class="logo-invert" src="https://mredgyusv1qtkwdp.public.blob.vercel-storage.com/bdic_tm_logo_white.svg" alt="BDIC" />
+          </span>
+          <span class="link-text">
+            <span class="link-label">BDIC</span>
+            <span class="link-sublabel">bdic.io</span>
+          </span>
+          <span class="link-arrow">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M7 17L17 7M17 7H7M17 7v10"/></svg>
+          </span>
+        </a>
+
+        <a class="link-item" href="https://astrolabe.finance" target="_blank" rel="noopener">
+          <span class="link-icon branded">
+            <!-- Astrolabe globe mark -->
+            <svg class="logo-invert" viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg" fill="white">
+              <path d="M159.803 145.732C147.866 145.732 138.168 136.023 138.168 124.097C138.168 120.697 135.389 117.918 131.989 117.918C128.588 117.918 125.809 120.697 125.809 124.097C125.809 136.034 116.1 145.732 104.175 145.732C100.774 145.732 97.9949 148.511 97.9949 151.911C97.9949 155.312 100.774 158.091 104.175 158.091C116.112 158.091 125.809 167.8 125.809 179.726C125.809 183.126 128.588 185.905 131.989 185.905C135.389 185.905 138.168 183.126 138.168 179.726C138.168 167.789 147.878 158.091 159.803 158.091C163.204 158.091 165.983 155.312 165.983 151.911C165.983 148.511 163.204 145.732 159.803 145.732Z"/>
+              <path d="M295.826 145.732C283.888 145.732 274.191 136.023 274.191 124.097C274.191 120.697 271.412 117.918 268.011 117.918C264.611 117.918 261.832 120.697 261.832 124.097C261.832 136.034 252.123 145.732 240.197 145.732C236.797 145.732 234.017 148.511 234.017 151.911C234.017 155.312 236.797 158.091 240.197 158.091C252.134 158.091 261.832 167.8 261.832 179.726C261.832 183.126 264.611 185.905 268.011 185.905C271.412 185.905 274.191 183.126 274.191 179.726C274.191 167.789 283.9 158.091 295.826 158.091C299.226 158.091 302.005 155.312 302.005 151.911C302.005 148.511 299.226 145.732 295.826 145.732Z"/>
+              <path d="M227.814 77.7205C215.877 77.7205 206.18 68.0113 206.18 56.0859C206.18 52.6853 203.401 49.9062 200 49.9062C196.599 49.9062 193.82 52.6853 193.82 56.0859C193.82 68.023 184.111 77.7205 172.186 77.7205C168.785 77.7205 166.006 80.4996 166.006 83.9002C166.006 87.3007 168.785 90.0798 172.186 90.0798C184.123 90.0798 193.82 99.789 193.82 111.714C193.82 115.115 196.599 117.894 200 117.894C203.401 117.894 206.18 115.115 206.18 111.714C206.18 99.7773 215.889 90.0798 227.814 90.0798C231.215 90.0798 233.994 87.3007 233.994 83.9002C233.994 80.4996 231.215 77.7205 227.814 77.7205Z"/>
+              <path d="M200 0C89.5403 0 0 89.5403 0 200C0 310.46 89.5403 400 200 400C310.46 400 400 310.46 400 200C400 89.5403 310.448 0 200 0ZM187.242 366.475C152.099 363.825 120.005 350.281 94.3011 329.233C114.986 298.663 148.569 277.545 187.242 273.698V366.475ZM187.242 254.01C142.835 257.821 104.081 281.356 79.7373 315.807C73.4053 309.228 67.6008 302.134 62.4062 294.583C91.6628 256.449 136.409 230.84 187.242 227.146V254.01ZM212.746 366.475V273.698C251.419 277.533 285.014 298.663 305.687 329.233C279.984 350.281 247.878 363.813 212.746 366.475ZM320.251 315.807C295.908 281.356 257.153 257.821 212.746 254.01V227.146C263.579 230.84 308.326 256.449 337.582 294.583C332.387 302.122 326.583 309.228 320.251 315.807ZM200 200C139.306 200 84.932 227.04 48.2645 269.723C38.4967 248.499 33.0441 224.894 33.0441 200C33.0441 107.786 107.798 33.0441 200 33.0441C292.202 33.0441 366.956 107.798 366.956 200C366.956 224.894 361.503 248.499 351.735 269.723C315.056 227.04 260.682 200 200 200Z"/>
+            </svg>
+          </span>
+          <span class="link-text">
+            <span class="link-label">Astrolabe</span>
+            <span class="link-sublabel">astrolabe.finance</span>
+          </span>
+          <span class="link-arrow">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M7 17L17 7M17 7H7M17 7v10"/></svg>
+          </span>
+        </a>
+      </div>
+
+      <!-- Contact -->
+      <div class="links">
+        <div class="section-label">Contact</div>
+        <a class="link-item" href="mailto:aaron@resolvr.io">
+          <span class="link-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+            </svg>
+          </span>
+          <span class="link-text">
+            <span class="link-label">aaron@resolvr.io</span>
+          </span>
+          <span class="link-arrow">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M7 17L17 7M17 7H7M17 7v10"/></svg>
+          </span>
+        </a>
+      </div>
+
+      <!-- Social -->
+      <div class="links">
+        <div class="section-label">Connect</div>
+        <div class="socials">
+          <a class="social-btn" href="https://www.linkedin.com/in/waarondanielappeals/" target="_blank" rel="noopener" aria-label="LinkedIn">
+            <!-- LinkedIn -->
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+            </svg>
+          </a>
+
+          <a class="social-btn" href="https://x.com/wadaniel" target="_blank" rel="noopener" aria-label="X">
+            <!-- X -->
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+            </svg>
+          </a>
+
+          <a class="social-btn" href="https://njump.me/npub16zxfxy5ltnp992gp006jlyy9qc93qanzpfvv66fznvc7xul0ej0suk5dzc" target="_blank" rel="noopener" aria-label="Nostr">
+            <!-- Nostr -->
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M18.3008 2.62402C17.8017 2.52565 17.4533 2.7122 17.29 3.1416C17.0308 3.756 17.1993 4.54412 17.7441 5.12012C17.9889 5.37917 18.2744 5.60226 18.5479 5.83496C18.7494 6.00773 18.9273 6.19705 19.0977 6.4082C19.5537 6.977 19.0713 8.0216 18.9561 8.1416C18.553 8.55899 18.2025 8.63519 17.5068 8.60645C16.8228 8.57765 15.0488 7.66161 14.1104 7.63281C11.7872 7.56082 10.1747 8.63367 9.62988 8.91211C8.81619 9.32853 7.65844 9.35514 7.61621 9.36719C7.09063 9.40799 6.00096 9.44954 5.46094 9.63672C4.70014 9.84792 4.28914 10.196 4.01074 10.9736C3.92446 11.3094 3.90798 11.6141 4.03027 11.7988C4.29666 12.202 5.01439 12.5378 5.34082 12.7227C5.50852 12.8185 5.83865 12.6991 5.9043 12.6533C6.2691 12.4061 6.59144 12.2118 7.02344 12.1494C7.1154 12.1349 7.7243 12.0275 8.03125 12.2529C8.25426 12.416 8.44647 12.5138 8.69824 12.6289C9.15701 12.8368 10.1655 13.0994 10.1934 13.1064C10.3302 13.1424 10.5059 13.2126 10.5059 13.335C10.5052 13.5082 8.89249 14.8561 8.80371 14.8896C8.39817 15.0552 8.16327 15.3221 8.08887 15.7061C8.06489 15.8307 8.00992 15.9603 7.94043 16.0635C7.67888 16.4426 6.51938 18.0885 6.21191 18.54C6.06563 18.7511 5.9146 18.8569 5.70605 18.8906C5.40621 18.9386 5.17997 18.9459 5.05273 19.1592C4.97356 19.2959 5.02437 19.5625 5.07715 19.7354C5.13706 19.9319 4.97432 20.1767 4.96191 20.2061C4.81791 20.4869 4.7577 20.7561 4.7793 21.0273C4.78648 21.1379 4.79384 21.3938 4.97559 21.4014C5.1578 21.411 5.20591 21.2933 5.22754 21.25C5.25394 21.1972 5.35499 20.9786 5.38379 20.9258C5.5015 20.7073 5.95059 20.2368 6.00098 20.1816C6.1644 20.0004 8.56152 16.6992 8.56152 16.6992C8.69346 16.5265 8.83062 16.3491 9.05371 16.2627C9.36321 16.1427 9.56989 15.8957 9.62988 15.5693C9.64428 15.4973 10.6018 14.7627 11.0098 14.4531C11.1589 14.3404 12.058 13.9788 12.0752 13.9824C12.0752 13.9896 11.25 15.2336 10.9932 15.8936C10.9524 15.9993 10.8848 16.3586 10.959 16.541C11.0742 16.8218 11.3217 16.9444 11.6025 16.8604C11.6888 16.834 11.7655 16.7908 11.8398 16.75C11.8733 16.7309 11.9069 16.714 11.9404 16.6973C11.974 16.6805 12.0055 16.6633 12.0391 16.6465C12.1158 16.6057 12.1903 16.5679 12.2646 16.5439C12.5406 16.4527 12.8193 16.3657 13.0977 16.2793L13.6611 16.1045C14.0547 15.9821 14.4492 15.8593 14.8428 15.7393C14.929 15.7129 15.0133 15.6822 15.1211 15.6846C15.1809 15.6847 15.2459 15.7085 15.2676 15.7969C15.2676 15.8017 15.3129 16.0707 15.4785 16.1787C15.5625 16.2339 15.7426 16.2773 15.877 16.2725C15.9944 16.2677 16.1429 16.3012 16.2197 16.3682L16.3184 16.4521C16.3903 16.5121 16.4791 16.5457 16.5391 16.5625C16.6015 16.5793 16.717 16.5794 16.7842 16.5098C16.8556 16.4333 16.83 16.3094 16.8203 16.2705C16.8059 16.2177 16.7765 16.1766 16.7549 16.1406L16.6953 16.0469C16.6377 15.9557 16.5824 15.8646 16.5225 15.7734C16.3569 15.5215 16.1933 15.272 16.0254 15.0225C15.8502 14.7633 15.5788 14.6596 15.2236 14.7148C15.0826 14.7379 12.0978 15.6641 12.0635 15.6729C12.2242 15.3777 13.186 14.0484 13.4551 13.8799C13.6542 13.7623 13.7384 13.6493 14.1006 13.5869C14.8086 13.4669 16.3449 13.1119 16.7266 12.8359C17.4678 12.2986 17.5275 11.0776 17.5156 10.832C17.5012 10.5873 17.5805 10.4185 17.7939 10.3057C17.8995 10.2505 19.0424 9.61967 19.6016 8.68848C19.9375 8.14372 20.1101 7.56058 20.043 6.91504C19.9998 6.49264 19.8606 6.11094 19.5918 5.77734C19.3542 5.48218 19.0497 5.27077 18.7617 5.0332C18.6177 4.9156 18.2355 4.59602 18.1875 4.41602C18.1302 4.19797 18.2193 3.97546 18.418 3.90332C18.718 3.80252 19.2203 3.80404 19.5107 3.82324C19.7578 3.84234 20.0119 3.75603 20.0215 3.65527C20.0307 3.55448 19.8846 3.4059 19.6904 3.36035C19.5369 3.32437 19.3018 3.26931 19.1602 3.17578C18.9082 3.00539 18.6511 2.69365 18.3008 2.62402Z"/>
+            </svg>
+          </a>
+        </div>
+      </div>
+
+      <div class="footer">&copy; 2026 Resolvr, Inc.</div>
+    </div>
+
+    <script>
+      (function () {
+        const toggle = document.querySelector(".theme-toggle");
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
+
+        function getTheme() {
+          const saved = localStorage.getItem("theme");
+          if (saved) return saved;
+          return prefersDark.matches ? "dark" : "light";
+        }
+
+        function applyTheme(theme) {
+          if (theme === "light") {
+            document.documentElement.setAttribute("data-theme", "light");
+          } else {
+            document.documentElement.removeAttribute("data-theme");
+          }
+        }
+
+        applyTheme(getTheme());
+
+        toggle.addEventListener("click", function () {
+          const current = getTheme();
+          const next = current === "dark" ? "light" : "dark";
+          localStorage.setItem("theme", next);
+          applyTheme(next);
+        });
+
+        prefersDark.addEventListener("change", function (e) {
+          if (!localStorage.getItem("theme")) {
+            applyTheme(e.matches ? "dark" : "light");
+          }
+        });
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Adds a mobile-first linktree-style page at `/aaron` for Aaron Daniel
- Resolvr orange/blue/black brand palette with Satoshi font
- Light/dark mode toggle respecting device preference
- Sections: profile photo, Resolvr logo, Featured (BDIC, Astrolabe), Contact (email), Connect (LinkedIn, X, Nostr)

## Test plan
- [ ] Verify page loads at pages.resolvr.io/aaron
- [ ] Test light/dark toggle and system preference detection
- [ ] Test all links open correctly
- [ ] Verify mobile layout on various screen sizes