### PR TITLE
Update Aaron card OG tags and social image

### DIFF
--- a/aaron/index.html
+++ b/aaron/index.html
@@ -6,14 +6,22 @@
     <title>Aaron Daniel — Resolvr</title>
 
     <meta name="description" content="Aaron Daniel — Co-Founder & CEO at Resolvr" />
+
+    <!-- Open Graph -->
     <meta property="og:title" content="Aaron Daniel — Resolvr" />
     <meta property="og:description" content="Co-Founder & CEO at Resolvr" />
-    <meta property="og:image" content="https://storage.ghost.io/c/dd/91/dd911265-70bb-414f-8e9e-4279996996d3/content/images/2023/10/WBD-Profile-Pic-2--1-.jpg" />
+    <meta property="og:image" content="https://mredgyusv1qtkwdp.public.blob.vercel-storage.com/business_cards/aaron_social_card.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:type" content="profile" />
-    <meta name="twitter:card" content="summary" />
+    <meta property="og:url" content="https://pages.resolvr.io/aaron" />
+    <meta property="og:site_name" content="Resolvr" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Aaron Daniel — Resolvr" />
     <meta name="twitter:description" content="Co-Founder & CEO at Resolvr" />
-    <meta name="twitter:image" content="https://storage.ghost.io/c/dd/91/dd911265-70bb-414f-8e9e-4279996996d3/content/images/2023/10/WBD-Profile-Pic-2--1-.jpg" />
+    <meta name="twitter:image" content="https://mredgyusv1qtkwdp.public.blob.vercel-storage.com/business_cards/aaron_social_card.png" />
 
     <link rel="icon" href="https://mredgyusv1qtkwdp.public.blob.vercel-storage.com/branding/logo/resolvr-logo-white.svg" type="image/svg+xml" />
 


### PR DESCRIPTION
## Summary
- Replace profile photo with dedicated social card image for OG/Twitter previews
- Upgrade Twitter card to `summary_large_image`
- Add `og:url`, `og:site_name`, and image dimension hints

## Test plan
- [ ] Validate with https://www.opengraph.xyz/url/https://pages.resolvr.io/aaron
- [ ] Check Twitter card preview