### PR TITLE
Update Astrolabe page header and background

### DIFF
--- a/astrolabe/index.html
+++ b/astrolabe/index.html
@@ -100,7 +100,7 @@
             <div class="header-content">
                 <a href="https://astrolabe.finance">
                     <img
-                        src="https://astrolabe.finance/astrolabe-by-resolvr.svg"
+                        src="https://mredgyusv1qtkwdp.public.blob.vercel-storage.com/astrolabe/logos/astrolabe-by-resolvr-white.svg"
                         alt="Astrolabe by Resolvr"
                         style="height: 40px; width: auto"
                     />

--- a/astrolabe/index.html
+++ b/astrolabe/index.html
@@ -57,13 +57,13 @@
             body {
                 font-family: "Satoshi", sans-serif;
                 font-weight: 400;
-                background-color: #132038;
+                background-color: #000F2A;
                 color: #000000;
                 display: flex;
                 flex-direction: column;
             }
             header {
-                background-color: #132038;
+                background-color: #000F2A;
                 padding: 1.5rem 2rem;
                 flex-shrink: 0;
             }
@@ -86,7 +86,7 @@
                 display: block;
             }
             footer {
-                background-color: #132038;
+                background-color: #000F2A;
                 color: #ffffff;
                 text-align: center;
                 padding: 0.75rem;

--- a/astrolabe/index.html
+++ b/astrolabe/index.html
@@ -57,13 +57,13 @@
             body {
                 font-family: "Satoshi", sans-serif;
                 font-weight: 400;
-                background-color: #000000;
+                background-color: #132038;
                 color: #000000;
                 display: flex;
                 flex-direction: column;
             }
             header {
-                background-color: #000000;
+                background-color: #132038;
                 padding: 1.5rem 2rem;
                 flex-shrink: 0;
             }
@@ -86,7 +86,7 @@
                 display: block;
             }
             footer {
-                background-color: #000000;
+                background-color: #132038;
                 color: #ffffff;
                 text-align: center;
                 padding: 0.75rem;
@@ -98,11 +98,11 @@
     <body>
         <header>
             <div class="header-content">
-                <a href="https://resolvr.io">
+                <a href="https://astrolabe.finance">
                     <img
-                        src="https://mredgyusv1qtkwdp.public.blob.vercel-storage.com/branding/logo/resolvr-logo-white.svg"
-                        alt="Resolvr Logo"
-                        style="width: 110px; height: auto"
+                        src="https://astrolabe.finance/astrolabe-by-resolvr.svg"
+                        alt="Astrolabe by Resolvr"
+                        style="height: 40px; width: auto"
                     />
                 </a>
             </div>


### PR DESCRIPTION
## Summary
- Replace Resolvr logo with Astrolabe by Resolvr lockup SVG (matching astrolabe.finance/info header)
- Change background color from black (#000) to dark blue (#132038) on header, footer, and body

## Test plan
- [ ] Verify logo loads from astrolabe.finance/astrolabe-by-resolvr.svg
- [ ] Check header/footer/body background matches #132038
- [ ] Confirm iframe form still displays correctly against new background